### PR TITLE
make constructor protected so that the class actually behaves like a …

### DIFF
--- a/includes/class-sikshya.php
+++ b/includes/class-sikshya.php
@@ -195,7 +195,7 @@ final class Sikshya
 	/**
 	 * Sikshya Constructor.
 	 */
-	public function __construct()
+	protected function __construct()
 	{
 		$this->define_constants();
 		$this->includes();


### PR DESCRIPTION
since the class had public constructor, it could be initialized without using the instance static method. Made constructor protected so that the class actually behaves as a singleton and can't be initialized without using the initialize method.