### PR TITLE
Improve security by sanitizing and escaping user input

### DIFF
--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -23,6 +23,11 @@ use Sikshya\Admin\ProUpgradeAdminNudge;
 use Sikshya\Admin\SetupWizardController;
 use Sikshya\Services\AdminMarketingNoticeService;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Admin Management Class
  *
@@ -30,15 +35,54 @@ use Sikshya\Services\AdminMarketingNoticeService;
  */
 class Admin
 {
+	/**
+	 * Registers the always-on Sikshya admin-chrome stylesheet and attaches the
+	 * menu-icon-sizing / setup-wizard-hiding rules (and, when relevant, the
+	 * React-shell chrome rules) as inline CSS instead of raw `echo`'d `<style>`
+	 * tags on `admin_head`.
+	 */
+	public static function enqueueSikshyaAdminInlineStyles(): void
+	{
+		wp_register_style('sikshya-admin-inline', false, [], SIKSHYA_VERSION);
+		wp_enqueue_style('sikshya-admin-inline');
+
+		wp_add_inline_style('sikshya-admin-inline', self::adminMenuIconCss());
+		wp_add_inline_style('sikshya-admin-inline', self::hideSetupWizardSubmenuCss());
+
+		if (self::isSikshyaReactAppRequest() || self::isSikshyaSetupWizardRequest()) {
+			wp_add_inline_style('sikshya-admin-inline', self::reactShellChromeCss());
+		}
+
+		if (self::isSikshyaAdminPage()) {
+			wp_add_inline_style('sikshya-admin-inline', self::dismissibleNoticeHidingCss());
+		}
+	}
+
+	/**
+	 * Hide dismissible WP core notices on Sikshya admin pages (they clutter the custom UI).
+	 */
+	private static function dismissibleNoticeHidingCss(): string
+	{
+		return '
+			.notice.is-dismissible,
+			.error.is-dismissible,
+			.updated.is-dismissible,
+			.update-nag,
+			.settings-error {
+				display: none !important;
+			}
+		';
+	}
+
     /**
      * Size the Sikshya top-level WP admin menu icon.
      *
      * When `add_menu_page()` receives an image URL, WordPress renders an `<img>` inside the menu icon slot.
      * Without a size override, custom logos can appear oversized/misaligned.
      */
-    public static function printSikshyaAdminMenuIconCss(): void
+	private static function adminMenuIconCss(): string
     {
-        echo '<style id="sikshya-admin-menu-icon">
+		return '
             #adminmenu #toplevel_page_sikshya .wp-menu-image img {
                 width: 20px;
                 height: 20px;
@@ -47,7 +91,7 @@ class Admin
                 display: block;
                 box-sizing: content-box;
             }
-        </style>';
+		';
     }
 
     /**
@@ -58,16 +102,13 @@ class Admin
      * {@see user_can_access_admin_page()} (wrong hook / empty parent) and shows
      * “Sorry, you are not allowed to access this page.” for direct wizard URLs.
      */
-    public static function hideSetupWizardSubmenuLink(): void
+	private static function hideSetupWizardSubmenuCss(): string
     {
-        if (!is_admin()) {
-            return;
-        }
-        echo '<style id="sikshya-hide-setup-wizard-menu-item">
+		return '
             #adminmenu #toplevel_page_sikshya .wp-submenu li:has(a[href*="page=sikshya-setup"]) {
                 display: none !important;
             }
-        </style>';
+		';
     }
 
     /**
@@ -139,12 +180,7 @@ class Admin
         add_action('admin_init', [self::class, 'redirectLegacySikshyaReactMenus'], 0);
         add_filter('show_admin_bar', [self::class, 'hideAdminBarOnSikshyaApp']);
         add_action('admin_enqueue_scripts', [self::class, 'dequeueWordPressUiOnSikshyaApp'], 10000);
-        add_action('admin_head', [self::class, 'printSikshyaReactShellHead'], 1);
-        add_action('admin_head', [self::class, 'printSikshyaAdminMenuIconCss'], 2);
-        add_action('admin_head', [self::class, 'hideSetupWizardSubmenuLink'], 3);
-
-        // Remove all other admin notices on Sikshya pages
-        add_action('admin_head', [$this, 'removeOtherNoticesOnSikshyaPages']);
+		add_action('admin_enqueue_scripts', [self::class, 'enqueueSikshyaAdminInlineStyles']);
 
         // Late strip: plugins often register `admin_notices` after `admin_init`.
         add_action('current_screen', [$this, 'stripAdminNoticesOnReactShell'], 0);
@@ -192,7 +228,7 @@ class Admin
          * Setup wizard: registered under Sikshya so `page=sikshya-setup` resolves and core access
          * checks see a parent (`get_admin_page_parent()` reads `$submenu`). Do not call
          * `remove_submenu_page()` — it drops the submenu row and breaks direct wizard URLs.
-         * The link is hidden via {@see hideSetupWizardSubmenuLink()}.
+		 * The link is hidden via {@see hideSetupWizardSubmenuCss()}.
          */
         add_submenu_page(
             AdminPages::DASHBOARD,
@@ -237,12 +273,9 @@ class Admin
     /**
      * Hide WP skip links and other chrome on the Sikshya full-screen shell.
      */
-    public static function printSikshyaReactShellHead(): void
+	private static function reactShellChromeCss(): string
     {
-        if (!self::isSikshyaReactAppRequest() && !self::isSikshyaSetupWizardRequest()) {
-            return;
-        }
-        echo '<style id="sikshya-react-wp-chrome-hide">
+		return '
             body.sikshya-react-shell .screen-reader-shortcut,
             body.sikshya-react-shell #wpbody-content > .screen-reader-text,
             body.sikshya-react-shell a[href="#wpbody-content"],
@@ -269,7 +302,7 @@ class Admin
             body.sikshya-react-shell #wpbody-content > p.notice {
                 display: none !important;
             }
-        </style>';
+		';
     }
 
     /**
@@ -730,7 +763,7 @@ class Admin
      *
      * @return bool
      */
-    private function isSikshyaAdminPage(): bool
+	private static function isSikshyaAdminPage(): bool
     {
         $screen = get_current_screen();
 
@@ -756,26 +789,6 @@ class Admin
         return $is_sikshya_post_screen
             || strpos($sid, 'sikshya') !== false
             || strpos($sbase, 'sikshya') !== false;
-    }
-
-    /**
-     * Remove WordPress notices on Sikshya pages using proper WordPress functions
-     */
-    public function removeOtherNoticesOnSikshyaPages(): void
-    {
-        if ($this->isSikshyaAdminPage()) {
-            // Simple CSS to hide only known WordPress notice classes
-            echo '<style>
-                /* Hide only specific WordPress admin notice classes */
-                .notice.is-dismissible,
-                .error.is-dismissible, 
-                .updated.is-dismissible,
-                .update-nag,
-                .settings-error {
-                    display: none !important;
-                }
-            </style>';
-        }
     }
 
     /**

--- a/src/Admin/Controllers/CourseCategoriesController.php
+++ b/src/Admin/Controllers/CourseCategoriesController.php
@@ -8,6 +8,11 @@ use Sikshya\Constants\Taxonomies;
 use Sikshya\Constants\PostTypes;
 use Sikshya\Utils\RichText;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Course Categories Controller
  *

--- a/src/Admin/Controllers/DashboardController.php
+++ b/src/Admin/Controllers/DashboardController.php
@@ -6,6 +6,11 @@ use Sikshya\Core\Plugin;
 use Sikshya\Services\AnalyticsService;
 use Sikshya\Services\CacheService;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Dashboard Controller
  *

--- a/src/Admin/Controllers/InstructorController.php
+++ b/src/Admin/Controllers/InstructorController.php
@@ -5,6 +5,11 @@ namespace Sikshya\Admin\Controllers;
 use Sikshya\Admin\ReactAdminView;
 use Sikshya\Core\Plugin;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Instructors admin — React shell only.
  *

--- a/src/Admin/Controllers/LessonController.php
+++ b/src/Admin/Controllers/LessonController.php
@@ -5,6 +5,11 @@ namespace Sikshya\Admin\Controllers;
 use Sikshya\Admin\ReactAdminView;
 use Sikshya\Core\Plugin;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Lesson admin — React shell only.
  *

--- a/src/Admin/Controllers/QuizController.php
+++ b/src/Admin/Controllers/QuizController.php
@@ -5,6 +5,11 @@ namespace Sikshya\Admin\Controllers;
 use Sikshya\Admin\ReactAdminView;
 use Sikshya\Core\Plugin;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Quiz admin — React shell only.
  *

--- a/src/Admin/Controllers/ReportController.php
+++ b/src/Admin/Controllers/ReportController.php
@@ -7,6 +7,11 @@ use Sikshya\Admin\ReactAdminView;
 use Sikshya\Core\Plugin;
 use Sikshya\Database\Repositories\ReportsRepository;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Reports data for the React admin (snapshot API). Legacy PHP report views and admin-ajax removed.
  *

--- a/src/Admin/Controllers/SettingController.php
+++ b/src/Admin/Controllers/SettingController.php
@@ -7,6 +7,11 @@ use Sikshya\Admin\Settings\SettingsManager;
 use Sikshya\Core\Plugin;
 use Sikshya\Admin\Views\BaseView;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Setting Controller Class
  *

--- a/src/Admin/Controllers/StudentController.php
+++ b/src/Admin/Controllers/StudentController.php
@@ -5,6 +5,11 @@ namespace Sikshya\Admin\Controllers;
 use Sikshya\Admin\ReactAdminView;
 use Sikshya\Core\Plugin;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Students admin — React shell only.
  *

--- a/src/Admin/Controllers/ToolsController.php
+++ b/src/Admin/Controllers/ToolsController.php
@@ -4,6 +4,11 @@ namespace Sikshya\Admin\Controllers;
 
 use Sikshya\Core\Plugin;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Tools area shell. Maintenance actions (e.g. import sample data) are handled by REST and
  * {@see \Sikshya\Admin\Controllers\SampleDataController} → {@see \Sikshya\Services\SampleDataImportService}.

--- a/src/Admin/CourseCategoryAdminRedirects.php
+++ b/src/Admin/CourseCategoryAdminRedirects.php
@@ -4,6 +4,11 @@ namespace Sikshya\Admin;
 
 use Sikshya\Constants\Taxonomies;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Routes course category management away from native WordPress term screens.
  *

--- a/src/Admin/ListTable/QuizzesListTable.php
+++ b/src/Admin/ListTable/QuizzesListTable.php
@@ -6,6 +6,11 @@ use Sikshya\Admin\ReactAdminConfig;
 use Sikshya\Constants\PostTypes;
 use Sikshya\Services\LessonCourseLink;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Quizzes List Table
  *

--- a/src/Admin/ListTable/StudentsListTable.php
+++ b/src/Admin/ListTable/StudentsListTable.php
@@ -6,6 +6,11 @@ use Sikshya\Admin\ReactAdminConfig;
 use Sikshya\Constants\PostTypes;
 use Sikshya\Database\Repositories\EnrollmentRepository;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Students List Table
  *

--- a/src/Admin/ProUpgradeAdminNudge.php
+++ b/src/Admin/ProUpgradeAdminNudge.php
@@ -5,6 +5,11 @@ namespace Sikshya\Admin;
 use Sikshya\Constants\AdminPages;
 use Sikshya\Licensing\PricingUrl;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * “Upgrade to Pro” entry points when no commercial Sikshya tier is active.
  *

--- a/src/Admin/ReactAdminConfig.php
+++ b/src/Admin/ReactAdminConfig.php
@@ -11,6 +11,11 @@ use Sikshya\Licensing\TierCapabilities;
 use Sikshya\Services\PermalinkService;
 use Sikshya\Services\Settings;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Bootstrap payload for the React admin shell (URL-based pages, full-width layout).
  */

--- a/src/Admin/ReactAdminView.php
+++ b/src/Admin/ReactAdminView.php
@@ -4,6 +4,11 @@ namespace Sikshya\Admin;
 
 use Sikshya\Constants\PostTypes;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Renders the React admin mount point and injects bootstrap config.
  */

--- a/src/Admin/Settings/SettingsManager.php
+++ b/src/Admin/Settings/SettingsManager.php
@@ -9,6 +9,11 @@ use Sikshya\Licensing\TierCapabilities;
 use Sikshya\Services\Settings;
 use Sikshya\Services\PermalinkService;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Settings Manager Class
  *

--- a/src/Admin/SetupWizardController.php
+++ b/src/Admin/SetupWizardController.php
@@ -7,6 +7,11 @@ use Sikshya\Core\Plugin;
 use Sikshya\Services\PermalinkService;
 use Sikshya\Services\Settings;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 final class SetupWizardController
 {
     public const MENU_SLUG = 'sikshya-setup';

--- a/src/Admin/Views/BaseView.php
+++ b/src/Admin/Views/BaseView.php
@@ -4,6 +4,11 @@ namespace Sikshya\Admin\Views;
 
 use Sikshya\Core\Plugin;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Base View Class for Custom UI Components
  *
@@ -109,7 +114,11 @@ abstract class BaseView
 
         if (file_exists($template_path)) {
             try {
-                extract($this->data);
+				// EXTR_SKIP: never overwrite a local in this scope (`$template_path`,
+				// `$template`, `$this`) — an unguarded extract() would silently clobber
+				// `$template_path` on the very next line if `$this->data` ever had a
+				// same-named key, redirecting the include to the wrong file.
+				extract($this->data, EXTR_SKIP);
                 include $template_path;
             } catch (\Exception $e) {
                 error_log('Sikshya BaseView: Template include error: ' . $e->getMessage());

--- a/src/Admin/Views/Dashboard.php
+++ b/src/Admin/Views/Dashboard.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Admin\Views;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Custom Dashboard Component
  *

--- a/src/Admin/Views/DataTable.php
+++ b/src/Admin/Views/DataTable.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Admin\Views;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Reusable DataTable Component
  *

--- a/src/Admin/Views/FormBuilder.php
+++ b/src/Admin/Views/FormBuilder.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Admin\Views;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Reusable FormBuilder Component
  *

--- a/src/Ajax/FrontendAjax.php
+++ b/src/Ajax/FrontendAjax.php
@@ -129,6 +129,16 @@ class FrontendAjax extends AjaxAbstract
             return;
         }
 
+		// Paid courses: block free enrollment (same rule as the active enrollment paths).
+		if (function_exists('sikshya_get_course_pricing')) {
+			$pricing = sikshya_get_course_pricing($course_id);
+			$is_paid = null !== $pricing['effective'] && (float) $pricing['effective'] > 0.00001;
+			if ($is_paid) {
+				$this->sendError('This course requires purchase.');
+				return;
+			}
+		}
+
         // Add enrollment
         if (!is_array($enrollment)) {
             $enrollment = [];

--- a/src/Api/AdminEmailTemplateRestRoutes.php
+++ b/src/Api/AdminEmailTemplateRestRoutes.php
@@ -11,6 +11,11 @@ use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Admin email template CRUD (React settings → Templates tab).
  *

--- a/src/Api/AdminLicenseRestRoutes.php
+++ b/src/Api/AdminLicenseRestRoutes.php
@@ -9,6 +9,11 @@ use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * License + upgrade UI REST. Commercial add-on supplies license operations via filters.
  *

--- a/src/Api/AdminMarketingNoticeRestRoutes.php
+++ b/src/Api/AdminMarketingNoticeRestRoutes.php
@@ -7,6 +7,11 @@ use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * REST for in-app marketing notices (React shell).
  *

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -6,6 +6,11 @@ use Sikshya\Core\Plugin;
 use Sikshya\Addons\Addons;
 use WP_REST_Server;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Main API Class
  *

--- a/src/Api/AttachmentProxyRoutes.php
+++ b/src/Api/AttachmentProxyRoutes.php
@@ -7,6 +7,11 @@ use Sikshya\Security\AttachmentTokenService;
 use WP_REST_Request;
 use WP_REST_Server;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * REST proxy that streams attachment files through Sikshya rather than
  * exposing the raw `wp-content/uploads/` URL.

--- a/src/Api/CertificateService.php
+++ b/src/Api/CertificateService.php
@@ -6,6 +6,11 @@ use Sikshya\Services\CertificateQueryService;
 use WP_REST_Request;
 use WP_REST_Response;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 class CertificateService
 {
     private CertificateQueryService $svc;

--- a/src/Api/CourseService.php
+++ b/src/Api/CourseService.php
@@ -5,6 +5,11 @@ namespace Sikshya\Api;
 use WP_REST_Request;
 use WP_REST_Response;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 class CourseService
 {
     /**

--- a/src/Api/EnrollmentService.php
+++ b/src/Api/EnrollmentService.php
@@ -7,6 +7,11 @@ use WP_REST_Request;
 use WP_REST_Response;
 use WP_Error;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 class EnrollmentService
 {
     private EnrollmentCrudService $svc;

--- a/src/Api/LessonService.php
+++ b/src/Api/LessonService.php
@@ -5,6 +5,11 @@ namespace Sikshya\Api;
 use WP_REST_Request;
 use WP_REST_Response;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 class LessonService
 {
     public function getLessons(WP_REST_Request $request): WP_REST_Response

--- a/src/Api/PaymentService.php
+++ b/src/Api/PaymentService.php
@@ -6,6 +6,11 @@ use Sikshya\Database\Repositories\PaymentRepository;
 use WP_REST_Request;
 use WP_REST_Response;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 class PaymentService
 {
     private PaymentRepository $payments;

--- a/src/Api/ProgressService.php
+++ b/src/Api/ProgressService.php
@@ -6,6 +6,11 @@ use Sikshya\Services\ProgressQueryService;
 use WP_REST_Request;
 use WP_REST_Response;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 class ProgressService
 {
     private ProgressQueryService $svc;

--- a/src/Api/QuizService.php
+++ b/src/Api/QuizService.php
@@ -5,6 +5,11 @@ namespace Sikshya\Api;
 use WP_REST_Request;
 use WP_REST_Response;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 class QuizService
 {
     public function getQuizzes(WP_REST_Request $request): WP_REST_Response

--- a/src/Api/UserService.php
+++ b/src/Api/UserService.php
@@ -5,6 +5,11 @@ namespace Sikshya\Api;
 use WP_REST_Request;
 use WP_REST_Response;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 class UserService
 {
     public function getUsers(WP_REST_Request $request): WP_REST_Response

--- a/src/Blocks/BlockPreviewMarkup.php
+++ b/src/Blocks/BlockPreviewMarkup.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Blocks;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Wraps dynamic block HTML for editor SSR previews.
  *

--- a/src/Blocks/BlocksRegistrar.php
+++ b/src/Blocks/BlocksRegistrar.php
@@ -6,6 +6,11 @@ use Sikshya\Core\Plugin;
 use Sikshya\Shortcodes\AuthShortcodes;
 use Sikshya\Shortcodes\CoursesShortcode;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Registers Sikshya Gutenberg blocks (dynamic; same output as shortcodes).
  *

--- a/src/Blocks/ContentHasSikshyaBlock.php
+++ b/src/Blocks/ContentHasSikshyaBlock.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Blocks;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Detect Sikshya blocks/shortcodes in post content (for asset loading).
  *

--- a/src/Blocks/PublicBlockStyles.php
+++ b/src/Blocks/PublicBlockStyles.php
@@ -4,6 +4,11 @@ namespace Sikshya\Blocks;
 
 use Sikshya\Core\Plugin;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Registers and attaches Sikshya public CSS to Gutenberg blocks.
  *

--- a/src/Certificates/CertificatePublic.php
+++ b/src/Certificates/CertificatePublic.php
@@ -5,6 +5,11 @@ namespace Sikshya\Certificates;
 use Sikshya\Database\Repositories\CertificateRepository;
 use Sikshya\Services\PermalinkService;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Public hash-based certificate page for the free plugin.
  *

--- a/src/Certificates/CertificateRenderer.php
+++ b/src/Certificates/CertificateRenderer.php
@@ -4,6 +4,11 @@ namespace Sikshya\Certificates;
 
 use Sikshya\Services\PermalinkService;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Lightweight public certificate renderer for the free plugin.
  *

--- a/src/Certificates/CertificateTemplateDefaults.php
+++ b/src/Certificates/CertificateTemplateDefaults.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Sikshya\Certificates;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Default seeded certificate templates: visual-builder layout JSON + rendered HTML body.
  *

--- a/src/Commerce/CheckoutService.php
+++ b/src/Commerce/CheckoutService.php
@@ -10,6 +10,11 @@ use Sikshya\Frontend\Site\PublicPageUrls;
 use Sikshya\Licensing\TierCapabilities;
 use Sikshya\Services\Settings;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * One-time checkout: offline (manual), Stripe Checkout Session, PayPal order creation, etc.
  *

--- a/src/Commerce/OrderFulfillmentService.php
+++ b/src/Commerce/OrderFulfillmentService.php
@@ -7,6 +7,11 @@ use Sikshya\Database\Repositories\PaymentRepository;
 use Sikshya\Services\CourseService;
 use Sikshya\Services\Settings;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Marks orders paid, enrolls learners, writes legacy payment rows.
  *

--- a/src/Commerce/OrderRefundService.php
+++ b/src/Commerce/OrderRefundService.php
@@ -6,6 +6,11 @@ use Sikshya\Database\Repositories\OrderRepository;
 use Sikshya\Database\Repositories\PaymentRepository;
 use Sikshya\Services\CourseService;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Reverses a paid Sikshya order in response to a payment refund.
  *

--- a/src/Commerce/PaymentGatewayRegistry.php
+++ b/src/Commerce/PaymentGatewayRegistry.php
@@ -4,6 +4,11 @@ namespace Sikshya\Commerce;
 
 use Sikshya\Licensing\TierCapabilities;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Payment gateway registry (extensible via filters).
  *

--- a/src/Constants/AdminPages.php
+++ b/src/Constants/AdminPages.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Constants;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Admin Page Constants
  *

--- a/src/Controllers/CourseController.php
+++ b/src/Controllers/CourseController.php
@@ -10,6 +10,11 @@ use Sikshya\Models\Lesson;
 use Sikshya\Models\Quiz;
 use Sikshya\Models\Enrollment;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Course Controller
  *

--- a/src/Core/Autoloader.php
+++ b/src/Core/Autoloader.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Core;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * PSR-4 Autoloader for Sikshya LMS
  *

--- a/src/Core/Deactivator.php
+++ b/src/Core/Deactivator.php
@@ -5,6 +5,11 @@ namespace Sikshya\Core;
 use Sikshya\Database\Repositories\PluginLifecycleRepository;
 use Sikshya\Services\Settings;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Plugin Deactivator
  *

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -30,6 +30,11 @@ use Sikshya\Blocks\BlocksRegistrar;
 use Sikshya\Shortcodes\CoursesShortcode;
 use Sikshya\Shortcodes\AuthShortcodes;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Main Plugin Class
  *

--- a/src/Core/Requirements.php
+++ b/src/Core/Requirements.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Core;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Plugin Requirements Checker
  *

--- a/src/Core/Uninstaller.php
+++ b/src/Core/Uninstaller.php
@@ -5,6 +5,11 @@ namespace Sikshya\Core;
 use Sikshya\Database\Repositories\PluginLifecycleRepository;
 use Sikshya\Services\Settings;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Plugin Uninstaller
  *

--- a/src/Core/View.php
+++ b/src/Core/View.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Core;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * View Class
  *

--- a/src/Database/Repositories/AchievementsRepository.php
+++ b/src/Database/Repositories/AchievementsRepository.php
@@ -7,6 +7,11 @@ namespace Sikshya\Database\Repositories;
 use Sikshya\Database\Repositories\Contracts\RepositoryInterface;
 use Sikshya\Database\Tables\AchievementsTable;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Reads + writes against the {@see AchievementsTable} (`sikshya_achievements`).
  *

--- a/src/Database/Repositories/AdminTablesRepository.php
+++ b/src/Database/Repositories/AdminTablesRepository.php
@@ -7,6 +7,11 @@ use Sikshya\Database\Tables\EnrollmentsTable;
 use Sikshya\Database\Tables\QuizAttemptsTable;
 use Sikshya\Database\Tables\PaymentsTable;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Admin-focused table listings (joins custom tables with WP users/posts).
  *
@@ -242,21 +247,20 @@ final class AdminTablesRepository
         }
 
         $where_sql = implode(' AND ', $where);
-        $table_sql = esc_sql($table);
 
-        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name escaped; values bound.
-        $total = (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM `{$table_sql}` a LEFT JOIN {$users_table} u ON u.ID = a.user_id LEFT JOIN {$posts_table} q ON q.ID = a.quiz_id LEFT JOIN {$posts_table} c ON c.ID = a.course_id WHERE {$where_sql}", ...$prepare));
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table is an internal constant (QuizAttemptsTable::getTableName()), not user input; values bound.
+		$total = (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM `{$table}` a LEFT JOIN {$users_table} u ON u.ID = a.user_id LEFT JOIN {$posts_table} q ON q.ID = a.quiz_id LEFT JOIN {$posts_table} c ON c.ID = a.course_id WHERE {$where_sql}", ...$prepare));
         $pages = $total > 0 ? (int) ceil($total / $per_page) : 0;
 
         $prepare_rows = array_merge($prepare, [$per_page, $offset]);
-        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name escaped; values bound.
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table is an internal constant (QuizAttemptsTable::getTableName()), not user input; values bound.
         $rows = $wpdb->get_results(
             $wpdb->prepare(
                 "SELECT a.id, a.user_id, a.quiz_id, a.course_id, a.attempt_number, a.score, a.status, a.started_at, a.completed_at,
                         u.display_name AS user_name, u.user_email AS user_email,
                         q.post_title AS quiz_title,
                         c.post_title AS course_title
-                 FROM `{$table_sql}` a
+				 FROM `{$table}` a
                  LEFT JOIN {$users_table} u ON u.ID = a.user_id
                  LEFT JOIN {$posts_table} q ON q.ID = a.quiz_id
                  LEFT JOIN {$posts_table} c ON c.ID = a.course_id

--- a/src/Database/Repositories/AnalyticsRepository.php
+++ b/src/Database/Repositories/AnalyticsRepository.php
@@ -4,6 +4,11 @@ namespace Sikshya\Database\Repositories;
 
 use Sikshya\Database\Tables\AnalyticsTable;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Write-only analytics event store (custom table).
  *

--- a/src/Database/Repositories/AssignmentSubmissionRepository.php
+++ b/src/Database/Repositories/AssignmentSubmissionRepository.php
@@ -4,6 +4,11 @@ namespace Sikshya\Database\Repositories;
 
 use Sikshya\Database\Tables\AssignmentSubmissionsTable;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Assignment submissions (custom table).
  *

--- a/src/Database/Repositories/CertificateRepository.php
+++ b/src/Database/Repositories/CertificateRepository.php
@@ -4,6 +4,11 @@ namespace Sikshya\Database\Repositories;
 
 use Sikshya\Database\Tables\CertificatesTable;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Issued certificates (custom table).
  *

--- a/src/Database/Repositories/CouponRepository.php
+++ b/src/Database/Repositories/CouponRepository.php
@@ -5,6 +5,11 @@ namespace Sikshya\Database\Repositories;
 use Sikshya\Database\Tables\CouponsTable;
 use Sikshya\Database\Tables\CouponRedemptionsTable;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Coupons + redemptions.
  *

--- a/src/Database/Repositories/CourseRepository.php
+++ b/src/Database/Repositories/CourseRepository.php
@@ -6,6 +6,11 @@ use Sikshya\Constants\PostTypes;
 use Sikshya\Database\Repositories\Contracts\RepositoryInterface;
 use WP_Query;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 class CourseRepository implements RepositoryInterface
 {
     public function findAll(array $args = []): array

--- a/src/Database/Repositories/EnrollmentRepository.php
+++ b/src/Database/Repositories/EnrollmentRepository.php
@@ -5,6 +5,11 @@ namespace Sikshya\Database\Repositories;
 use Sikshya\Database\Repositories\Contracts\RepositoryInterface;
 use Sikshya\Database\Tables\EnrollmentsTable;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 class EnrollmentRepository implements RepositoryInterface
 {
     private string $table_name;

--- a/src/Database/Repositories/InstructorApplicationsRepository.php
+++ b/src/Database/Repositories/InstructorApplicationsRepository.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Database\Repositories;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * User-meta queries for instructor applications (pending / approved / rejected).
  *

--- a/src/Database/Repositories/InstructorMetricsRepository.php
+++ b/src/Database/Repositories/InstructorMetricsRepository.php
@@ -5,6 +5,11 @@ namespace Sikshya\Database\Repositories;
 use Sikshya\Constants\PostTypes;
 use Sikshya\Database\Tables\EnrollmentsTable;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Instructor dashboard metrics (core posts + enrollments custom table).
  *

--- a/src/Database/Repositories/LessonRepository.php
+++ b/src/Database/Repositories/LessonRepository.php
@@ -7,6 +7,11 @@ use Sikshya\Services\LessonCourseLink;
 use Sikshya\Database\Repositories\Contracts\RepositoryInterface;
 use WP_Query;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 class LessonRepository implements RepositoryInterface
 {
     public function findAll(array $args = []): array

--- a/src/Database/Repositories/LogRepository.php
+++ b/src/Database/Repositories/LogRepository.php
@@ -4,6 +4,11 @@ namespace Sikshya\Database\Repositories;
 
 use Sikshya\Database\Tables\LogsTable;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Write-only log store (custom table).
  *

--- a/src/Database/Repositories/OrderRepository.php
+++ b/src/Database/Repositories/OrderRepository.php
@@ -5,6 +5,11 @@ namespace Sikshya\Database\Repositories;
 use Sikshya\Database\Tables\OrdersTable;
 use Sikshya\Database\Tables\OrderItemsTable;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Checkout orders + line items.
  *

--- a/src/Database/Repositories/PaymentRepository.php
+++ b/src/Database/Repositories/PaymentRepository.php
@@ -4,6 +4,11 @@ namespace Sikshya\Database\Repositories;
 
 use Sikshya\Database\Tables\PaymentsTable;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Legacy payment rows (sikshya_payments).
  *

--- a/src/Database/Repositories/PluginLifecycleRepository.php
+++ b/src/Database/Repositories/PluginLifecycleRepository.php
@@ -4,6 +4,11 @@ namespace Sikshya\Database\Repositories;
 
 use Sikshya\Database\Tables\Tables;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Deactivation / uninstall maintenance (options table, custom table drops).
  *

--- a/src/Database/Repositories/ProgressRepository.php
+++ b/src/Database/Repositories/ProgressRepository.php
@@ -6,6 +6,11 @@ use Sikshya\Database\Repositories\Contracts\RepositoryInterface;
 use Sikshya\Database\Tables\ProgressTable;
 use Sikshya\Services\LearnerCurriculumHelper;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 class ProgressRepository implements RepositoryInterface
 {
     private string $table_name;
@@ -21,6 +26,55 @@ class ProgressRepository implements RepositoryInterface
 
         return $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $this->table_name)) === $this->table_name;
     }
+
+	/**
+	 * Whitelisted progress columns that are safe to sort by. MySQL
+	 * identifiers can't be parameterised by `$wpdb->prepare()`, so any
+	 * ORDER BY interpolation is a latent SQLi trap the day a caller
+	 * starts forwarding request params here.
+	 */
+	private const SAFE_ORDERBY = [
+		'id' => 'id',
+		'user_id' => 'user_id',
+		'course_id' => 'course_id',
+		'lesson_id' => 'lesson_id',
+		'quiz_id' => 'quiz_id',
+		'status' => 'status',
+		'percentage' => 'percentage',
+		'time_spent' => 'time_spent',
+		'completed_date' => 'completed_date',
+		'updated_at' => 'updated_at',
+	];
+
+	/**
+	 * Normalise the paging / ordering args every list-style query in this
+	 * repository consumes. Enforces a hard whitelist on the identifier,
+	 * clamps direction to ASC/DESC, and int-casts the paging cursors so
+	 * no downstream method has to remember to do it.
+	 *
+	 * @param array<string, mixed> $args
+	 * @return array{orderby: string, order: string, limit: int, offset: int}
+	 */
+	private static function normalizeOrderArgs(array $args): array
+	{
+		$orderby_in = strtolower((string) ($args['orderby'] ?? 'updated_at'));
+		$orderby = self::SAFE_ORDERBY[$orderby_in] ?? 'updated_at';
+
+		$order = strtoupper((string) ($args['order'] ?? 'DESC'));
+		if ($order !== 'ASC' && $order !== 'DESC') {
+			$order = 'DESC';
+		}
+
+		$limit = max(0, min(500, (int) ($args['limit'] ?? 10)));
+		$offset = max(0, (int) ($args['offset'] ?? 0));
+
+		return [
+			'orderby' => $orderby,
+			'order' => $order,
+			'limit' => $limit,
+			'offset' => $offset,
+		];
+	}
 
     /**
      * Query progress rows by user/course filters.
@@ -62,18 +116,11 @@ class ProgressRepository implements RepositoryInterface
     {
         global $wpdb;
 
-        $defaults = [
-            'limit' => 10,
-            'offset' => 0,
-            'orderby' => 'updated_at',
-            'order' => 'DESC',
-        ];
-
-        $args = wp_parse_args($args, $defaults);
+		$safe = self::normalizeOrderArgs($args);
 
         $sql = "SELECT * FROM {$this->table_name}";
-        $sql .= " ORDER BY {$args['orderby']} {$args['order']}";
-        $sql .= " LIMIT {$args['limit']} OFFSET {$args['offset']}";
+		$sql .= " ORDER BY {$safe['orderby']} {$safe['order']}";
+		$sql .= " LIMIT {$safe['limit']} OFFSET {$safe['offset']}";
 
         return $wpdb->get_results($sql);
     }
@@ -163,18 +210,11 @@ class ProgressRepository implements RepositoryInterface
     {
         global $wpdb;
 
-        $defaults = [
-            'limit' => 10,
-            'offset' => 0,
-            'orderby' => 'updated_at',
-            'order' => 'DESC',
-        ];
-
-        $args = wp_parse_args($args, $defaults);
+		$safe = self::normalizeOrderArgs($args);
 
         $sql = $wpdb->prepare("SELECT * FROM {$this->table_name} WHERE user_id = %d", $user_id);
-        $sql .= " ORDER BY {$args['orderby']} {$args['order']}";
-        $sql .= " LIMIT {$args['limit']} OFFSET {$args['offset']}";
+		$sql .= " ORDER BY {$safe['orderby']} {$safe['order']}";
+		$sql .= " LIMIT {$safe['limit']} OFFSET {$safe['offset']}";
 
         return $wpdb->get_results($sql);
     }
@@ -183,18 +223,11 @@ class ProgressRepository implements RepositoryInterface
     {
         global $wpdb;
 
-        $defaults = [
-            'limit' => 10,
-            'offset' => 0,
-            'orderby' => 'updated_at',
-            'order' => 'DESC',
-        ];
-
-        $args = wp_parse_args($args, $defaults);
+		$safe = self::normalizeOrderArgs($args);
 
         $sql = $wpdb->prepare("SELECT * FROM {$this->table_name} WHERE course_id = %d", $course_id);
-        $sql .= " ORDER BY {$args['orderby']} {$args['order']}";
-        $sql .= " LIMIT {$args['limit']} OFFSET {$args['offset']}";
+		$sql .= " ORDER BY {$safe['orderby']} {$safe['order']}";
+		$sql .= " LIMIT {$safe['limit']} OFFSET {$safe['offset']}";
 
         return $wpdb->get_results($sql);
     }

--- a/src/Database/Repositories/QuizAttemptRepository.php
+++ b/src/Database/Repositories/QuizAttemptRepository.php
@@ -5,6 +5,11 @@ namespace Sikshya\Database\Repositories;
 use Sikshya\Database\Tables\QuizAttemptsTable;
 use Sikshya\Database\Tables\QuizAttemptItemsTable;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Table-backed quiz attempts + per-question rows.
  *

--- a/src/Database/Repositories/ReportsRepository.php
+++ b/src/Database/Repositories/ReportsRepository.php
@@ -8,6 +8,11 @@ use Sikshya\Database\Tables\EnrollmentsTable;
 use Sikshya\Database\Tables\PaymentsTable;
 use Sikshya\Services\Settings;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Admin reports / gradebook-style aggregates over custom tables.
  *

--- a/src/Database/Tables/AbstractTable.php
+++ b/src/Database/Tables/AbstractTable.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Database\Tables;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 abstract class AbstractTable implements TableInterface
 {
     public static function getTableName(): string

--- a/src/Database/Tables/AchievementsTable.php
+++ b/src/Database/Tables/AchievementsTable.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Database\Tables;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 final class AchievementsTable extends AbstractTable
 {
     public static function baseName(): string

--- a/src/Database/Tables/AnalyticsTable.php
+++ b/src/Database/Tables/AnalyticsTable.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Database\Tables;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 final class AnalyticsTable extends AbstractTable
 {
     public static function baseName(): string

--- a/src/Database/Tables/AssignmentSubmissionsTable.php
+++ b/src/Database/Tables/AssignmentSubmissionsTable.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Database\Tables;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 final class AssignmentSubmissionsTable extends AbstractTable
 {
     public static function baseName(): string

--- a/src/Database/Tables/CertificatesTable.php
+++ b/src/Database/Tables/CertificatesTable.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Database\Tables;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 final class CertificatesTable extends AbstractTable
 {
     public static function baseName(): string

--- a/src/Database/Tables/CouponRedemptionsTable.php
+++ b/src/Database/Tables/CouponRedemptionsTable.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Database\Tables;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 final class CouponRedemptionsTable extends AbstractTable
 {
     public static function baseName(): string

--- a/src/Database/Tables/CouponsTable.php
+++ b/src/Database/Tables/CouponsTable.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Database\Tables;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 final class CouponsTable extends AbstractTable
 {
     public static function baseName(): string

--- a/src/Database/Tables/EnrollmentsTable.php
+++ b/src/Database/Tables/EnrollmentsTable.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Database\Tables;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 final class EnrollmentsTable extends AbstractTable
 {
     public static function baseName(): string

--- a/src/Database/Tables/LessonContentTable.php
+++ b/src/Database/Tables/LessonContentTable.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Database\Tables;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 final class LessonContentTable extends AbstractTable
 {
     public static function baseName(): string

--- a/src/Database/Tables/LogsTable.php
+++ b/src/Database/Tables/LogsTable.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Database\Tables;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 final class LogsTable extends AbstractTable
 {
     public static function baseName(): string

--- a/src/Database/Tables/NotificationsTable.php
+++ b/src/Database/Tables/NotificationsTable.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Database\Tables;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 final class NotificationsTable extends AbstractTable
 {
     public static function baseName(): string

--- a/src/Database/Tables/OrderItemsTable.php
+++ b/src/Database/Tables/OrderItemsTable.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Database\Tables;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 final class OrderItemsTable extends AbstractTable
 {
     public static function baseName(): string

--- a/src/Database/Tables/OrdersTable.php
+++ b/src/Database/Tables/OrdersTable.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Database\Tables;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 final class OrdersTable extends AbstractTable
 {
     public static function baseName(): string

--- a/src/Database/Tables/PaymentsTable.php
+++ b/src/Database/Tables/PaymentsTable.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Database\Tables;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 final class PaymentsTable extends AbstractTable
 {
     public static function baseName(): string

--- a/src/Database/Tables/ProgressTable.php
+++ b/src/Database/Tables/ProgressTable.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Database\Tables;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 final class ProgressTable extends AbstractTable
 {
     public static function baseName(): string

--- a/src/Database/Tables/QuizAttemptItemsTable.php
+++ b/src/Database/Tables/QuizAttemptItemsTable.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Database\Tables;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 final class QuizAttemptItemsTable extends AbstractTable
 {
     public static function baseName(): string

--- a/src/Database/Tables/QuizAttemptsTable.php
+++ b/src/Database/Tables/QuizAttemptsTable.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Database\Tables;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 final class QuizAttemptsTable extends AbstractTable
 {
     public static function baseName(): string

--- a/src/Database/Tables/QuizQuestionsTable.php
+++ b/src/Database/Tables/QuizQuestionsTable.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Database\Tables;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 final class QuizQuestionsTable extends AbstractTable
 {
     public static function baseName(): string

--- a/src/Database/Tables/ReviewsTable.php
+++ b/src/Database/Tables/ReviewsTable.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Database\Tables;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 final class ReviewsTable extends AbstractTable
 {
     public static function baseName(): string

--- a/src/Database/Tables/TableInterface.php
+++ b/src/Database/Tables/TableInterface.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Database\Tables;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 interface TableInterface
 {
     /**

--- a/src/Database/Tables/Tables.php
+++ b/src/Database/Tables/Tables.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Database\Tables;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 final class Tables
 {
     /**

--- a/src/Frontend/Controllers/AssignmentController.php
+++ b/src/Frontend/Controllers/AssignmentController.php
@@ -4,6 +4,11 @@ namespace Sikshya\Frontend\Controllers;
 
 use Sikshya\Core\Plugin;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Frontend Assignment Controller
  *

--- a/src/Frontend/Controllers/CertificateController.php
+++ b/src/Frontend/Controllers/CertificateController.php
@@ -5,6 +5,11 @@ namespace Sikshya\Frontend\Controllers;
 use Sikshya\Core\Plugin;
 use Sikshya\Frontend\Site\PublicPageUrls;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Frontend Certificate Controller
  *

--- a/src/Frontend/Controllers/CourseController.php
+++ b/src/Frontend/Controllers/CourseController.php
@@ -7,6 +7,11 @@ use Sikshya\Services\CourseFrontendSettings;
 use Sikshya\Services\CourseService;
 use WP_Query;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 class CourseController
 {
     private Plugin $plugin;

--- a/src/Frontend/Controllers/DiscussionController.php
+++ b/src/Frontend/Controllers/DiscussionController.php
@@ -4,6 +4,11 @@ namespace Sikshya\Frontend\Controllers;
 
 use Sikshya\Core\Plugin;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Frontend Discussion Controller
  *

--- a/src/Frontend/Controllers/EnrollmentController.php
+++ b/src/Frontend/Controllers/EnrollmentController.php
@@ -5,6 +5,11 @@ namespace Sikshya\Frontend\Controllers;
 use Sikshya\Core\Plugin;
 use Sikshya\Constants\PostTypes;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Frontend Enrollment Controller
  *

--- a/src/Frontend/Controllers/LessonController.php
+++ b/src/Frontend/Controllers/LessonController.php
@@ -4,6 +4,11 @@ namespace Sikshya\Frontend\Controllers;
 
 use Sikshya\Core\Plugin;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Frontend Lesson Controller
  *

--- a/src/Frontend/Controllers/ProgressController.php
+++ b/src/Frontend/Controllers/ProgressController.php
@@ -4,6 +4,11 @@ namespace Sikshya\Frontend\Controllers;
 
 use Sikshya\Core\Plugin;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Frontend Progress Controller
  *

--- a/src/Frontend/Controllers/QuizController.php
+++ b/src/Frontend/Controllers/QuizController.php
@@ -4,6 +4,11 @@ namespace Sikshya\Frontend\Controllers;
 
 use Sikshya\Core\Plugin;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Frontend Quiz Controller
  *

--- a/src/Frontend/Controllers/UserController.php
+++ b/src/Frontend/Controllers/UserController.php
@@ -5,6 +5,11 @@ namespace Sikshya\Frontend\Controllers;
 use Sikshya\Core\Plugin;
 use Sikshya\Frontend\Site\PublicPageUrls;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Frontend User Controller
  *

--- a/src/Frontend/Frontend.php
+++ b/src/Frontend/Frontend.php
@@ -25,6 +25,11 @@ use Sikshya\Frontend\Controllers\AssignmentController;
 use Sikshya\Blocks\ContentHasSikshyaBlock;
 use Sikshya\Shortcodes\AuthShortcodes;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Frontend Management Class
  *

--- a/src/Frontend/Site/AccountTemplateData.php
+++ b/src/Frontend/Site/AccountTemplateData.php
@@ -14,6 +14,11 @@ use Sikshya\Services\LearnerCurriculumHelper;
 use Sikshya\Core\Plugin;
 use Sikshya\Services\PublicCurriculumService;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Learner dashboard data for the account page.
  *

--- a/src/Frontend/Site/ArchiveContextTemplateData.php
+++ b/src/Frontend/Site/ArchiveContextTemplateData.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Frontend\Site;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Shared view-model for archive/taxonomy templates.
  *

--- a/src/Frontend/Site/CartFlashResolver.php
+++ b/src/Frontend/Site/CartFlashResolver.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Frontend\Site;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Resolves cart / enrollment flash messages from the request (query args + short-lived transients).
  *

--- a/src/Frontend/Site/CartFormHandler.php
+++ b/src/Frontend/Site/CartFormHandler.php
@@ -5,6 +5,11 @@ namespace Sikshya\Frontend\Site;
 use Sikshya\Core\Plugin;
 use Sikshya\Services\CourseService;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * POST handler for cart and free enrollment actions (no logic in templates).
  *

--- a/src/Frontend/Site/CartStorage.php
+++ b/src/Frontend/Site/CartStorage.php
@@ -4,6 +4,11 @@ namespace Sikshya\Frontend\Site;
 
 use Sikshya\Constants\PostTypes;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Persists course IDs for the storefront cart (user meta + guest cookie).
  * Optional {@see self::BUNDLE_META_KEY} when the cart matches a Pro course bundle.

--- a/src/Frontend/Site/CartTemplateData.php
+++ b/src/Frontend/Site/CartTemplateData.php
@@ -4,6 +4,11 @@ namespace Sikshya\Frontend\Site;
 
 use Sikshya\Constants\PostTypes;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * @package Sikshya\Frontend\Site
  */

--- a/src/Frontend/Site/CertificatesAccountView.php
+++ b/src/Frontend/Site/CertificatesAccountView.php
@@ -5,6 +5,11 @@ namespace Sikshya\Frontend\Site;
 use Sikshya\Core\Plugin;
 use Sikshya\Services\LearnerCertificateService;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Learner account: Certificates view + sidebar link.
  *

--- a/src/Frontend/Site/CheckoutDynamicFieldsView.php
+++ b/src/Frontend/Site/CheckoutDynamicFieldsView.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Frontend\Site;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Server-rendered markup for checkout dynamic fields (matches assets/js/checkout-page.js structure).
  *

--- a/src/Frontend/Site/CheckoutTemplateData.php
+++ b/src/Frontend/Site/CheckoutTemplateData.php
@@ -6,6 +6,11 @@ use Sikshya\Commerce\PaymentGatewayRegistry;
 use Sikshya\Licensing\TierCapabilities;
 use Sikshya\Services\Settings;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * @package Sikshya\Frontend\Site
  */

--- a/src/Frontend/Site/CourseRatingPrompt.php
+++ b/src/Frontend/Site/CourseRatingPrompt.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Frontend\Site;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Prompts learners to rate a course after completion.
  *

--- a/src/Frontend/Site/CoursesGridTemplateData.php
+++ b/src/Frontend/Site/CoursesGridTemplateData.php
@@ -5,6 +5,11 @@ namespace Sikshya\Frontend\Site;
 use Sikshya\Constants\PostTypes;
 use Sikshya\Constants\Taxonomies;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * View-model for the legacy `templates/courses-grid.php` browse layout.
  *

--- a/src/Frontend/Site/CurriculumOutlineMeta.php
+++ b/src/Frontend/Site/CurriculumOutlineMeta.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Frontend\Site;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Builds human-readable outline strings for sidebar curriculum rows.
  *

--- a/src/Frontend/Site/InstructorAccountView.php
+++ b/src/Frontend/Site/InstructorAccountView.php
@@ -7,6 +7,11 @@ use Sikshya\Core\Plugin;
 use Sikshya\Database\Repositories\InstructorMetricsRepository;
 use Sikshya\Admin\ReactAdminConfig;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Wires the "Teaching" (instructor) account view + sidebar group on the learner
  * account page so signed-in instructors get a role-aware experience without a

--- a/src/Frontend/Site/InstructorApplicationView.php
+++ b/src/Frontend/Site/InstructorApplicationView.php
@@ -4,6 +4,11 @@ namespace Sikshya\Frontend\Site;
 
 use Sikshya\Core\Plugin;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Account: "Apply for instructor" view for learners.
  *

--- a/src/Frontend/Site/InstructorContext.php
+++ b/src/Frontend/Site/InstructorContext.php
@@ -4,6 +4,11 @@ namespace Sikshya\Frontend\Site;
 
 use Sikshya\Database\Repositories\InstructorMetricsRepository;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Determines whether a user should see the instructor (teaching) account experience.
  *

--- a/src/Frontend/Site/OrderTemplateData.php
+++ b/src/Frontend/Site/OrderTemplateData.php
@@ -6,6 +6,11 @@ use Sikshya\Constants\PostTypes;
 use Sikshya\Database\Repositories\OrderRepository;
 use Sikshya\Services\Settings;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * @package Sikshya\Frontend\Site
  */

--- a/src/Frontend/Site/PublicPageUrls.php
+++ b/src/Frontend/Site/PublicPageUrls.php
@@ -6,6 +6,11 @@ use Sikshya\Services\PermalinkService;
 use Sikshya\Services\LearnPublicIdService;
 use Sikshya\Constants\PostTypes;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Resolves Sikshya frontend virtual page URLs (cart, checkout, learn, …).
  *

--- a/src/Frontend/Site/QuizTemplateData.php
+++ b/src/Frontend/Site/QuizTemplateData.php
@@ -15,6 +15,11 @@ use Sikshya\Services\Frontend\QuizPageService;
 use Sikshya\Services\LessonCourseLink;
 use Sikshya\Services\Settings;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * @package Sikshya\Frontend\Site
  */

--- a/src/Frontend/Site/SingleCourseTemplateData.php
+++ b/src/Frontend/Site/SingleCourseTemplateData.php
@@ -10,6 +10,11 @@ use Sikshya\Services\Settings;
 use Sikshya\Presentation\Models\SingleCoursePageModel;
 use Sikshya\Services\Frontend\SingleCoursePageService;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * View-model for {@see templates/single-course.php} (no business logic in the template file).
  *

--- a/src/Frontend/Site/UserCourseStateCache.php
+++ b/src/Frontend/Site/UserCourseStateCache.php
@@ -5,6 +5,11 @@ namespace Sikshya\Frontend\Site;
 use Sikshya\Database\Repositories\CertificateRepository;
 use Sikshya\Database\Repositories\EnrollmentRepository;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Request-scoped cache for (user × course) state used by archive cards.
  *

--- a/src/Helpers/Icons.php
+++ b/src/Helpers/Icons.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Helpers;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Shared SVG icon paths from {@see assets/admin/icons/icons.json} for PHP templates.
  */

--- a/src/Licensing/PricingUrl.php
+++ b/src/Licensing/PricingUrl.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Sikshya\Licensing;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Canonical pricing-page URLs with UTM tagging.
  *

--- a/src/Models/Enrollment.php
+++ b/src/Models/Enrollment.php
@@ -5,6 +5,11 @@ namespace Sikshya\Models;
 use Sikshya\Constants\PostTypes;
 use Sikshya\Database\Repositories\EnrollmentRepository;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Legacy enrollment facade — all persistence goes through {@see EnrollmentRepository}.
  *

--- a/src/Models/Lesson.php
+++ b/src/Models/Lesson.php
@@ -5,6 +5,11 @@ namespace Sikshya\Models;
 use Sikshya\Services\LessonCourseLink;
 use WP_Post;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Lesson Model
  *

--- a/src/Models/Quiz.php
+++ b/src/Models/Quiz.php
@@ -4,6 +4,11 @@ namespace Sikshya\Models;
 
 use WP_Post;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Quiz Model
  *

--- a/src/Privacy/PersonalDataEraser.php
+++ b/src/Privacy/PersonalDataEraser.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Privacy;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * GDPR personal-data eraser for Sikshya.
  *

--- a/src/Privacy/PersonalDataExporter.php
+++ b/src/Privacy/PersonalDataExporter.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Privacy;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * GDPR personal-data exporter for Sikshya.
  *

--- a/src/Security/AdminBackendAccess.php
+++ b/src/Security/AdminBackendAccess.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Security;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Shared capability checks for Sikshya's wp-admin React shell and staff-only REST endpoints.
  *

--- a/src/Security/AttachmentTokenService.php
+++ b/src/Security/AttachmentTokenService.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Security;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * HMAC-signed download tokens for course/lesson attachments.
  *

--- a/src/Security/LoginRateLimiter.php
+++ b/src/Security/LoginRateLimiter.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Security;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Transient-based brute-force protection for the Sikshya auth endpoints.
  *

--- a/src/Security/RegistrationRateLimiter.php
+++ b/src/Security/RegistrationRateLimiter.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Sikshya\Security;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Transient-based throttling for the `/auth/web-register` and
  * `/auth/register` endpoints.

--- a/src/Security/SecretVault.php
+++ b/src/Security/SecretVault.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Sikshya\Security;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Envelope-encrypted secret storage.
  *

--- a/src/Services/AdminAssetsService.php
+++ b/src/Services/AdminAssetsService.php
@@ -6,6 +6,11 @@ use Sikshya\Admin\SetupWizardController;
 use Sikshya\Core\Plugin;
 use Sikshya\Constants\PostTypes;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Admin Asset Management Service
  *

--- a/src/Services/AdminMarketingNoticeService.php
+++ b/src/Services/AdminMarketingNoticeService.php
@@ -7,6 +7,11 @@ use Sikshya\Database\Repositories\OrderRepository;
 use Sikshya\Licensing\PricingUrl;
 use WP_Error;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Admin marketing notices (classic WP admin + Sikshya React shell), modelled on Yatra’s {@see \Yatra\Services\NoticeService}.
  *

--- a/src/Services/AnalyticsService.php
+++ b/src/Services/AnalyticsService.php
@@ -5,6 +5,11 @@ namespace Sikshya\Services;
 use Sikshya\Core\Plugin;
 use Sikshya\Database\Repositories\AnalyticsRepository;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Analytics Service
  *

--- a/src/Services/CacheService.php
+++ b/src/Services/CacheService.php
@@ -4,6 +4,11 @@ namespace Sikshya\Services;
 
 use Sikshya\Core\Plugin;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Cache Management Service
  *

--- a/src/Services/CertificateIssuanceService.php
+++ b/src/Services/CertificateIssuanceService.php
@@ -7,6 +7,11 @@ use Sikshya\Database\Repositories\CertificateRepository;
 use Sikshya\Certificates\CertificateRenderer;
 use Sikshya\Certificates\CertificateTemplateDefaults;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Creates rows in sikshya_certificates when a learner completes a course.
  *

--- a/src/Services/CertificateQueryService.php
+++ b/src/Services/CertificateQueryService.php
@@ -4,6 +4,11 @@ namespace Sikshya\Services;
 
 use Sikshya\Database\Repositories\CertificateRepository;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Read-only certificate queries for REST.
  */

--- a/src/Services/CourseCompletionEvaluator.php
+++ b/src/Services/CourseCompletionEvaluator.php
@@ -4,6 +4,11 @@ namespace Sikshya\Services;
 
 use Sikshya\Database\Repositories\ProgressRepository;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Enrollment progress % and completion rules from global course settings.
  *

--- a/src/Services/CourseDeleteCascade.php
+++ b/src/Services/CourseDeleteCascade.php
@@ -10,6 +10,11 @@ use Sikshya\Database\Tables\EnrollmentsTable;
 use Sikshya\Database\Tables\ProgressTable;
 use Sikshya\Database\Tables\QuizAttemptsTable;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Cascade cleanup when a course post is permanently deleted.
  *

--- a/src/Services/CourseFrontendSettings.php
+++ b/src/Services/CourseFrontendSettings.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Services;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Reads course catalog / archive settings stored via {@see Settings}.
  *

--- a/src/Services/CourseService.php
+++ b/src/Services/CourseService.php
@@ -8,6 +8,11 @@ use Sikshya\Database\Repositories\ProgressRepository;
 use Sikshya\Services\Enrollment\EnrollmentValidator;
 use WP_Query;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 class CourseService
 {
     private CourseRepository $courseRepository;

--- a/src/Services/CustomEmailTemplateHookDispatcher.php
+++ b/src/Services/CustomEmailTemplateHookDispatcher.php
@@ -4,6 +4,11 @@ namespace Sikshya\Services;
 
 use Sikshya\Database\Repositories\OrderRepository;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Registers WordPress hooks for custom email templates so stored {@see EmailTemplateStore} `event` keys actually send mail.
  *

--- a/src/Services/EmailNotificationService.php
+++ b/src/Services/EmailNotificationService.php
@@ -6,6 +6,11 @@ use Sikshya\Database\Repositories\CertificateRepository;
 use Sikshya\Database\Repositories\OrderRepository;
 use Sikshya\Frontend\Site\PublicPageUrls;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Basic email notifications (wp_mail) with editable templates.
  *

--- a/src/Services/EmailRecipientResolver.php
+++ b/src/Services/EmailRecipientResolver.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Services;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Resolves "Send to" expressions (merge tags or legacy learner/admin/instructor) to a single email address.
  *

--- a/src/Services/EmailTemplateCatalog.php
+++ b/src/Services/EmailTemplateCatalog.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Services;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Built-in transactional email definitions (merge with per-site overrides in EmailTemplateStore).
  *

--- a/src/Services/EmailTemplateGate.php
+++ b/src/Services/EmailTemplateGate.php
@@ -6,6 +6,11 @@ use Sikshya\Addons\Addons;
 use Sikshya\Licensing\FeatureRegistry;
 use Sikshya\Licensing\TierCapabilities;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Add-on / plan gates for transactional email templates (match {@see SettingsManager} semantics).
  *

--- a/src/Services/EmailTemplateMerge.php
+++ b/src/Services/EmailTemplateMerge.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Services;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Replace {{merge_tags}} in email subject/body.
  *

--- a/src/Services/EmailTemplateStore.php
+++ b/src/Services/EmailTemplateStore.php
@@ -4,6 +4,11 @@ namespace Sikshya\Services;
 
 use Sikshya\Utils\RichText;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Per-site email template overrides and custom templates.
  *

--- a/src/Services/Enrollment/EnrollmentValidator.php
+++ b/src/Services/Enrollment/EnrollmentValidator.php
@@ -8,6 +8,11 @@ use Sikshya\Database\Repositories\CourseRepository;
 use Sikshya\Database\Repositories\EnrollmentRepository;
 use Sikshya\Services\Settings;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Centralized policy gate for "is this user allowed to enroll in this course right now?".
  *

--- a/src/Services/EnrollmentCrudService.php
+++ b/src/Services/EnrollmentCrudService.php
@@ -5,6 +5,11 @@ namespace Sikshya\Services;
 use Sikshya\Database\Repositories\EnrollmentRepository;
 use WP_Error;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Business logic for enrollment CRUD used by REST controllers.
  */

--- a/src/Services/Frontend/AccountPageService.php
+++ b/src/Services/Frontend/AccountPageService.php
@@ -86,12 +86,32 @@ final class AccountPageService
          *
          */
         $partialPath = apply_filters('sikshya_account_view_template', $defaultPartial, $view, $legacy);
-        if (!is_string($partialPath) || !is_readable($partialPath)) {
+		if (!is_string($partialPath) || !self::isSafeTemplatePath($partialPath)) {
             $partialPath = $plugin->getTemplatePath('partials/account-view-dashboard.php');
         }
 
         return (string) $partialPath;
     }
+
+	/**
+	 * Whether a filter-supplied template path is readable AND resolves inside
+	 * wp-content (themes/plugins) rather than an arbitrary filesystem location
+	 * a compromised/misbehaving addon could point `sikshya_account_view_template` at.
+	 */
+	private static function isSafeTemplatePath(string $path): bool
+	{
+		$real = realpath($path);
+		if ($real === false || !is_readable($real)) {
+			return false;
+		}
+
+		$content_dir = realpath(WP_CONTENT_DIR);
+		if ($content_dir === false) {
+			return false;
+		}
+
+		return strpos($real, $content_dir . DIRECTORY_SEPARATOR) === 0;
+	}
 
     private static function handleProfilePost(): void
     {

--- a/src/Services/Frontend/CartPageService.php
+++ b/src/Services/Frontend/CartPageService.php
@@ -5,6 +5,11 @@ namespace Sikshya\Services\Frontend;
 use Sikshya\Frontend\Site\CartTemplateData;
 use Sikshya\Presentation\Models\CartPageModel;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 final class CartPageService
 {
     public static function build(): CartPageModel

--- a/src/Services/Frontend/CheckoutPageService.php
+++ b/src/Services/Frontend/CheckoutPageService.php
@@ -5,6 +5,11 @@ namespace Sikshya\Services\Frontend;
 use Sikshya\Frontend\Site\CheckoutTemplateData;
 use Sikshya\Presentation\Models\CheckoutPageModel;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 final class CheckoutPageService
 {
     public static function build(): CheckoutPageModel

--- a/src/Services/Frontend/LearnPageService.php
+++ b/src/Services/Frontend/LearnPageService.php
@@ -13,6 +13,11 @@ use Sikshya\Services\Settings;
 use Sikshya\Frontend\Site\CurriculumOutlineMeta;
 use Sikshya\Frontend\Site\PublicPageUrls;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Application service: learn hub / course curriculum / bundle views.
  * Produces a {@see LearnPageModel} for model-only templates. No HTML.

--- a/src/Services/Frontend/LessonPageService.php
+++ b/src/Services/Frontend/LessonPageService.php
@@ -13,6 +13,11 @@ use Sikshya\Services\LessonCourseLink;
 use Sikshya\Services\PublicCurriculumService;
 use Sikshya\Services\Settings;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Builds the single-lesson shell view model for enrolled / preview learners.
  *

--- a/src/Services/Frontend/OrderPageService.php
+++ b/src/Services/Frontend/OrderPageService.php
@@ -5,6 +5,11 @@ namespace Sikshya\Services\Frontend;
 use Sikshya\Frontend\Site\OrderTemplateData;
 use Sikshya\Presentation\Models\OrderPageModel;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 final class OrderPageService
 {
     public static function fromRequest(): OrderPageModel

--- a/src/Services/Frontend/SingleCoursePageService.php
+++ b/src/Services/Frontend/SingleCoursePageService.php
@@ -5,6 +5,11 @@ namespace Sikshya\Services\Frontend;
 use Sikshya\Frontend\Site\SingleCourseTemplateData;
 use Sikshya\Presentation\Models\SingleCoursePageModel;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Single-course landing page builder (service layer wrapper).
  *

--- a/src/Services/FrontendAssetsService.php
+++ b/src/Services/FrontendAssetsService.php
@@ -10,6 +10,11 @@ use Sikshya\Frontend\Site\PublicPageUrls;
 use Sikshya\Services\PermalinkService;
 use Sikshya\Shortcodes\AuthShortcodes;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Frontend Asset Management Service
  *

--- a/src/Services/GlobalSettingsBootstrap.php
+++ b/src/Services/GlobalSettingsBootstrap.php
@@ -7,6 +7,11 @@ namespace Sikshya\Services;
 use Sikshya\Constants\PostTypes;
 use Sikshya\Constants\Taxonomies;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Wires Sikshya Global Settings (React / {@see \Sikshya\Admin\Settings\SettingsManager}) into runtime behavior.
  *

--- a/src/Services/InstructorApplicationsService.php
+++ b/src/Services/InstructorApplicationsService.php
@@ -5,6 +5,11 @@ namespace Sikshya\Services;
 use Sikshya\Database\Repositories\InstructorApplicationsRepository;
 use Sikshya\Frontend\Site\InstructorContext;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Approve / reject instructor applications stored in user meta.
  *

--- a/src/Services/InstructorPermissions.php
+++ b/src/Services/InstructorPermissions.php
@@ -6,6 +6,11 @@ namespace Sikshya\Services;
 
 use Sikshya\Constants\PostTypes;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Global Settings → Instructors: permission toggles for the instructor role.
  *

--- a/src/Services/LearnPublicIdService.php
+++ b/src/Services/LearnPublicIdService.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Services;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Stable public ids for Learn player items (lesson/quiz/assignment).
  *

--- a/src/Services/LearnerAchievementStub.php
+++ b/src/Services/LearnerAchievementStub.php
@@ -7,6 +7,11 @@ namespace Sikshya\Services;
 use Sikshya\Database\Repositories\AchievementsRepository;
 use Sikshya\Database\Repositories\EnrollmentRepository;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Learner achievement / badge service.
  *

--- a/src/Services/LearnerActivityStub.php
+++ b/src/Services/LearnerActivityStub.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Services;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Placeholder until activity module is wired.
  *

--- a/src/Services/LearnerCertificateService.php
+++ b/src/Services/LearnerCertificateService.php
@@ -4,6 +4,11 @@ namespace Sikshya\Services;
 
 use Sikshya\Database\Repositories\CertificateRepository;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Learner certificates (table-backed).
  *

--- a/src/Services/LearnerCertificateStub.php
+++ b/src/Services/LearnerCertificateStub.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Services;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Placeholder until certificate learner API is fully wired.
  *

--- a/src/Services/LearnerCurriculumHelper.php
+++ b/src/Services/LearnerCurriculumHelper.php
@@ -4,6 +4,11 @@ namespace Sikshya\Services;
 
 use Sikshya\Constants\PostTypes;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Resolve lesson / quiz / assignment IDs from course curriculum meta
  * (chapters → contents).

--- a/src/Services/LearnerEnrollmentService.php
+++ b/src/Services/LearnerEnrollmentService.php
@@ -4,6 +4,11 @@ namespace Sikshya\Services;
 
 use Sikshya\Database\Repositories\EnrollmentRepository;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Learner enrollment checks for frontend controllers (Model layer).
  *

--- a/src/Services/LearnerQuizStatsStub.php
+++ b/src/Services/LearnerQuizStatsStub.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Services;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Placeholder until quiz stats aggregation is wired for the learner dashboard.
  *

--- a/src/Services/LearningProgressService.php
+++ b/src/Services/LearningProgressService.php
@@ -5,6 +5,11 @@ namespace Sikshya\Services;
 use Sikshya\Database\Repositories\EnrollmentRepository;
 use Sikshya\Database\Repositories\ProgressRepository;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Learner-facing progress API used by frontend controllers (Model layer).
  *

--- a/src/Services/LessonCourseLink.php
+++ b/src/Services/LessonCourseLink.php
@@ -6,6 +6,11 @@ namespace Sikshya\Services;
 
 use Sikshya\Constants\PostTypes;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Canonical read/write helpers for linking lesson/quiz/assignment posts to a parent course.
  *

--- a/src/Services/LessonService.php
+++ b/src/Services/LessonService.php
@@ -4,6 +4,11 @@ namespace Sikshya\Services;
 
 use Sikshya\Database\Repositories\LessonRepository;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 class LessonService
 {
     private LessonRepository $lessonRepository;

--- a/src/Services/LogService.php
+++ b/src/Services/LogService.php
@@ -5,6 +5,11 @@ namespace Sikshya\Services;
 use Sikshya\Core\Plugin;
 use Sikshya\Database\Repositories\LogRepository;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Logging Service
  *

--- a/src/Services/PermalinkService.php
+++ b/src/Services/PermalinkService.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Services;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Virtual frontend routes (cart, checkout, account, learn, order) and permalink option keys.
  *

--- a/src/Services/PostTypeService.php
+++ b/src/Services/PostTypeService.php
@@ -6,6 +6,11 @@ use Sikshya\Core\Plugin;
 use Sikshya\Constants\PostTypes;
 use Sikshya\PostTypes\PostTypeManager;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Post Type Management Service
  *

--- a/src/Services/ProgressQueryService.php
+++ b/src/Services/ProgressQueryService.php
@@ -4,6 +4,11 @@ namespace Sikshya\Services;
 
 use Sikshya\Database\Repositories\ProgressRepository;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Read-only progress queries for REST.
  */

--- a/src/Services/PublicCurriculumService.php
+++ b/src/Services/PublicCurriculumService.php
@@ -4,6 +4,11 @@ namespace Sikshya\Services;
 
 use Sikshya\Constants\PostTypes;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Read-only curriculum tree for learner-facing templates.
  *

--- a/src/Services/QuestionTypeService.php
+++ b/src/Services/QuestionTypeService.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Services;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Question Type Service
  *

--- a/src/Services/QuizService.php
+++ b/src/Services/QuizService.php
@@ -5,6 +5,11 @@ namespace Sikshya\Services;
 use Sikshya\Constants\PostTypes;
 use Sikshya\Database\Repositories\QuizAttemptRepository;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Learner quiz runtime + stats (table-backed).
  *

--- a/src/Services/SecurityService.php
+++ b/src/Services/SecurityService.php
@@ -4,6 +4,11 @@ namespace Sikshya\Services;
 
 use Sikshya\Core\Plugin;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Security Service
  *

--- a/src/Services/Settings.php
+++ b/src/Services/Settings.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Services;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Centralized settings read/write helper.
  *

--- a/src/Services/StatsUsage.php
+++ b/src/Services/StatsUsage.php
@@ -6,6 +6,11 @@ namespace Sikshya\Services;
 
 use WP_Error;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Sikshya usage telemetry (opt-in, privacy-safe).
  *

--- a/src/Services/SystemInfoService.php
+++ b/src/Services/SystemInfoService.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Services;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Collects environment/system info for admin tools.
  */

--- a/src/Services/TaxonomyService.php
+++ b/src/Services/TaxonomyService.php
@@ -6,6 +6,11 @@ use Sikshya\Core\Plugin;
 use Sikshya\Constants\PostTypes;
 use Sikshya\Constants\Taxonomies;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Taxonomy Management Service
  *

--- a/src/Services/WpMailSmtpBridge.php
+++ b/src/Services/WpMailSmtpBridge.php
@@ -5,6 +5,11 @@ namespace Sikshya\Services;
 use Sikshya\Addons\Addons;
 use Sikshya\Licensing\TierCapabilities;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Optional SMTP transport for wp_mail (commercial tier when email_advanced_customization is licensed).
  *

--- a/src/Shortcodes/AuthShortcodes.php
+++ b/src/Shortcodes/AuthShortcodes.php
@@ -6,6 +6,11 @@ use Sikshya\Frontend\Site\CartStorage;
 use Sikshya\Services\PermalinkService;
 use WP_Error;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Shortcodes:
  * - [sikshya_login]

--- a/src/Shortcodes/CoursesShortcode.php
+++ b/src/Shortcodes/CoursesShortcode.php
@@ -5,6 +5,11 @@ namespace Sikshya\Shortcodes;
 use Sikshya\Constants\PostTypes;
 use Sikshya\Constants\Taxonomies;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Shortcode: [sikshya_courses]
  *

--- a/src/Utils/EnsurePostSlug.php
+++ b/src/Utils/EnsurePostSlug.php
@@ -4,6 +4,11 @@ namespace Sikshya\Utils;
 
 use Sikshya\Constants\PostTypes;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Some posts can end up with an empty slug (post_name), commonly when the title
  * contains only characters that sanitize_title() strips. That results in 404s on

--- a/src/Utils/RichText.php
+++ b/src/Utils/RichText.php
@@ -2,6 +2,11 @@
 
 namespace Sikshya\Utils;
 
+// phpcs:ignore
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Central rich text sanitization + rendering helpers.
  *

--- a/templates/account.php
+++ b/templates/account.php
@@ -5,6 +5,10 @@
  * @package Sikshya
  */
 
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 use Sikshya\Core\Plugin;
 use Sikshya\Helpers\Icons;
 use Sikshya\Services\Frontend\AccountPageService;
@@ -30,7 +34,7 @@ $label_quiz = function_exists('sikshya_label') ? sikshya_label('quiz', __('Quiz'
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex, nofollow">
     <title><?php echo esc_html($page_model->getPageTitle()); ?></title>
-    <link rel="stylesheet" href="<?php echo $sheet_href; ?>">
+	<link rel="stylesheet" href="<?php echo esc_url($sheet_href); ?>">
     <?php
     /*
      * Minimal extension point for account-shell pages.

--- a/templates/admin/setup-wizard.php
+++ b/templates/admin/setup-wizard.php
@@ -266,7 +266,7 @@ $progress_pct = (int) round($initial_step / $total_steps * 100);
                 ?>
                 <<?php echo esc_attr($tag); ?>
                     class="sikshya-setup__rail-step <?php echo esc_attr($state_class); ?>"
-                    <?php if ($tag === 'a') : ?>href="<?php echo $url; ?>"<?php endif; ?>
+					<?php if ($tag === 'a') : ?>href="<?php echo esc_url($url); ?>"<?php endif; ?>
                     <?php if ($is_current) : ?>aria-current="step"<?php endif; ?>
                 >
                     <span class="sikshya-setup__rail-dot" aria-hidden="true">
@@ -306,7 +306,7 @@ $progress_pct = (int) round($initial_step / $total_steps * 100);
 
         <p class="sikshya-setup__toast" data-setup-toast hidden role="status"></p>
 
-        <form class="sikshya-setup__form" method="post" action="<?php echo $action_url; ?>" data-setup-form novalidate>
+		<form class="sikshya-setup__form" method="post" action="<?php echo esc_url($action_url); ?>" data-setup-form novalidate>
             <?php wp_nonce_field('sikshya_setup_wizard', 'sikshya_setup_nonce'); ?>
             <input type="hidden" name="return_step" value="<?php echo esc_attr((string) $initial_step); ?>" />
 

--- a/templates/archive-sik_course.php
+++ b/templates/archive-sik_course.php
@@ -5,6 +5,10 @@
  * @package Sikshya
  */
 
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 sikshya_get_header();
 
 $f = sikshya_course_archive_get_filter_request();

--- a/templates/cart.php
+++ b/templates/cart.php
@@ -5,6 +5,10 @@
  * @package Sikshya
  */
 
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 use Sikshya\Services\Frontend\CartPageService;
 use Sikshya\Presentation\Models\CartPageModel;
 use Sikshya\Services\Settings;

--- a/templates/checkout.php
+++ b/templates/checkout.php
@@ -5,6 +5,10 @@
  * @package Sikshya
  */
 
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 use Sikshya\Services\Frontend\CheckoutPageService;
 use Sikshya\Presentation\Models\CheckoutPageModel;
 use Sikshya\Services\Settings;
@@ -76,12 +80,18 @@ $checkout_js_config = [
  * @param CheckoutPageModel    $page_model
  */
 $checkout_js_config = apply_filters('sikshya_checkout_js_config', $checkout_js_config, $co, $page_model);
+
+// `sikshya-checkout-page` is enqueued in the footer (see Frontend::enqueuePageSpecificAssets()),
+// so registering this inline addition here — before wp_footer() runs — still prints it
+// immediately ahead of the script tag.
+wp_add_inline_script(
+	'sikshya-checkout-page',
+	'window.sikshyaCheckoutConfig = ' . wp_json_encode($checkout_js_config) . ';',
+	'before'
+);
 ?>
 
 <div <?php foreach ($root_attrs as $attr => $val) echo ' ' . esc_attr((string) $attr) . '="' . esc_attr((string) $val) . '"'; ?>>
-    <script>
-      window.sikshyaCheckoutConfig = <?php echo wp_json_encode($checkout_js_config); ?>;
-    </script>
     <header class="sikshya-course-lp__masthead">
         <div class="sikshya-container sikshya-container--course sikshya-course-lp__masthead-inner">
             <?php

--- a/templates/courses/index.php
+++ b/templates/courses/index.php
@@ -5,6 +5,10 @@
  * @package Sikshya
  */
 
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 use Sikshya\Constants\PostTypes;
 
 sikshya_get_header(); ?>

--- a/templates/learn.php
+++ b/templates/learn.php
@@ -5,6 +5,10 @@
  * @package Sikshya
  */
 
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 use Sikshya\Frontend\Site\LearnTemplateData;
 use Sikshya\Core\Plugin;
 
@@ -33,8 +37,8 @@ $page_title = sprintf(
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex, nofollow">
     <title><?php echo esc_html($page_title); ?></title>
-    <link rel="stylesheet" href="<?php echo $ds_href; ?>">
-    <link rel="stylesheet" href="<?php echo $learn_href; ?>">
+	<link rel="stylesheet" href="<?php echo esc_url($ds_href); ?>">
+	<link rel="stylesheet" href="<?php echo esc_url($learn_href); ?>">
     <?php
     /**
      * Extension point for learn-shell <head> (no wp_head() — keeps the shell minimal).

--- a/templates/login.php
+++ b/templates/login.php
@@ -5,6 +5,10 @@
  * @package Sikshya
  */
 
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 use Sikshya\Frontend\Site\PublicPageUrls;
 use Sikshya\Shortcodes\AuthShortcodes;
 

--- a/templates/order-invoice.php
+++ b/templates/order-invoice.php
@@ -5,6 +5,10 @@
  * @package Sikshya
  */
 
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 use Sikshya\Services\Frontend\OrderPageService;
 use Sikshya\Presentation\Models\OrderPageModel;
 

--- a/templates/order.php
+++ b/templates/order.php
@@ -5,6 +5,10 @@
  * @package Sikshya
  */
 
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 use Sikshya\Services\Frontend\OrderPageService;
 use Sikshya\Presentation\Models\OrderPageModel;
 use Sikshya\Core\Plugin;

--- a/templates/partials/account-view-dashboard.php
+++ b/templates/partials/account-view-dashboard.php
@@ -8,6 +8,10 @@
  * @var \Sikshya\Presentation\Models\AccountPageModel $page_model
  */
 
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 $display_name = $page_model->getDisplayName();
 $today_line   = $page_model->getTodayLine();
 $greeting     = $page_model->getGreeting();

--- a/templates/partials/account-view-instructor-apply.php
+++ b/templates/partials/account-view-instructor-apply.php
@@ -8,6 +8,10 @@
  * @var \Sikshya\Presentation\Models\AccountPageModel $page_model
  */
 
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 $uid = $page_model->getUserId();
 $app = is_array($acc['instructor_application'] ?? null) ? (array) $acc['instructor_application'] : [];
 $status = (string) ($app['status'] ?? '');

--- a/templates/partials/account-view-instructor.php
+++ b/templates/partials/account-view-instructor.php
@@ -10,6 +10,10 @@
  * @var \Sikshya\Presentation\Models\AccountPageModel $page_model
  */
 
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 use Sikshya\Frontend\Site\PublicPageUrls;
 
 $inst = $page_model->getInstructorVm();

--- a/templates/partials/account-view-learning.php
+++ b/templates/partials/account-view-learning.php
@@ -8,6 +8,10 @@
  * @var \Sikshya\Presentation\Models\AccountPageModel $page_model
  */
 
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 use Sikshya\Frontend\Site\PublicPageUrls;
 
 $label_course = function_exists('sikshya_label') ? sikshya_label('course', __('Course', 'sikshya'), 'frontend') : __('Course', 'sikshya');

--- a/templates/partials/account-view-payments.php
+++ b/templates/partials/account-view-payments.php
@@ -8,6 +8,10 @@
  * @var \Sikshya\Presentation\Models\AccountPageModel $page_model
  */
 
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 use Sikshya\Frontend\Site\PublicPageUrls;
 
 ?>

--- a/templates/partials/account-view-profile.php
+++ b/templates/partials/account-view-profile.php
@@ -8,6 +8,10 @@
  * @var \Sikshya\Presentation\Models\AccountPageModel  $page_model
  */
 
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 $uid = $page_model->getUserId();
 $user = $uid > 0 ? get_userdata($uid) : false;
 $first_name = $user ? (string) $user->first_name : '';

--- a/templates/partials/account-view-quiz-attempts.php
+++ b/templates/partials/account-view-quiz-attempts.php
@@ -8,6 +8,10 @@
  * @var \Sikshya\Presentation\Models\AccountPageModel $page_model
  */
 
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 ?>
             <?php
             $label_quiz = function_exists('sikshya_label') ? sikshya_label('quiz', __('Quiz', 'sikshya'), 'frontend') : __('Quiz', 'sikshya');

--- a/templates/partials/learn-curriculum-outline.php
+++ b/templates/partials/learn-curriculum-outline.php
@@ -7,6 +7,10 @@
  * @package Sikshya
  */
 
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 if (!isset($outline_blocks) || !is_array($outline_blocks)) {
     return;
 }

--- a/templates/partials/learn-icons.php
+++ b/templates/partials/learn-icons.php
@@ -8,6 +8,10 @@
  * @package Sikshya
  */
 
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 if (!function_exists('sikshya_learn_icon')) {
     /**
      * Return inline SVG markup for a named icon used in the learn shell.

--- a/templates/single-course.php
+++ b/templates/single-course.php
@@ -5,6 +5,10 @@
  * @package Sikshya
  */
 
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 use Sikshya\Constants\PostTypes;
 use Sikshya\Frontend\Site\PublicPageUrls;
 use Sikshya\Frontend\Site\SingleCourseTemplateData;

--- a/templates/single-lesson.php
+++ b/templates/single-lesson.php
@@ -5,6 +5,10 @@
  * @package Sikshya
  */
 
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 use Sikshya\Frontend\Site\LessonLearnContent;
 use Sikshya\Frontend\Site\LessonTemplateData;
 use Sikshya\Core\Plugin;
@@ -36,8 +40,8 @@ while (have_posts()) :
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex, nofollow">
     <title><?php echo esc_html($page_title); ?></title>
-    <link rel="stylesheet" href="<?php echo $ds_href; ?>">
-    <link rel="stylesheet" href="<?php echo $learn_href; ?>">
+	<link rel="stylesheet" href="<?php echo esc_url($ds_href); ?>">
+	<link rel="stylesheet" href="<?php echo esc_url($learn_href); ?>">
     <?php
     /**
      * Extension point for lesson-shell <head> (no wp_head() — keeps the shell minimal).

--- a/templates/single-quiz.php
+++ b/templates/single-quiz.php
@@ -39,8 +39,8 @@ while (have_posts()) {
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex, nofollow">
     <title><?php echo esc_html($page_title); ?></title>
-    <link rel="stylesheet" href="<?php echo $ds_href; ?>">
-    <link rel="stylesheet" href="<?php echo $learn_href; ?>">
+	<link rel="stylesheet" href="<?php echo esc_url($ds_href); ?>">
+	<link rel="stylesheet" href="<?php echo esc_url($learn_href); ?>">
 </head>
 <body class="sikshya-learning-shell sikshya-learning-shell--quiz">
 <a class="sikshya-skipLink" href="#sikshya-learn-content"><?php esc_html_e('Skip to quiz content', 'sikshya'); ?></a>
@@ -218,7 +218,7 @@ while (have_posts()) {
                   );
                   ?>;
                 </script>
-                <script src="<?php echo $quiz_js; ?>" defer></script>
+				<script src="<?php echo esc_url($quiz_js); ?>" defer></script>
             <?php endif; ?>
 
         <main class="sikshya-learnMain">

--- a/templates/taxonomy-course-category-root.php
+++ b/templates/taxonomy-course-category-root.php
@@ -5,6 +5,10 @@
  * @package Sikshya
  */
 
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 use Sikshya\Constants\PostTypes;
 use Sikshya\Constants\Taxonomies;
 use Sikshya\Frontend\Site\PublicPageUrls;

--- a/templates/taxonomy-course-category.php
+++ b/templates/taxonomy-course-category.php
@@ -5,6 +5,10 @@
  * @package Sikshya
  */
 
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 use Sikshya\Constants\PostTypes;
 use Sikshya\Frontend\Site\PublicPageUrls;
 

--- a/templates/taxonomy-course-tag.php
+++ b/templates/taxonomy-course-tag.php
@@ -5,6 +5,10 @@
  * @package Sikshya
  */
 
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 use Sikshya\Constants\PostTypes;
 
 sikshya_get_header();


### PR DESCRIPTION
## Summary

- Hardened three latent/edge-case security issues found in a full-plugin audit: an un-whitelisted `ORDER BY`/`LIMIT` interpolation path in `ProgressRepository`, a missing paid-course guard in a dormant enrollment AJAX handler, and an unrestricted filter-supplied template path in the account page service.
- Closed a WordPress Plugin Check (PCP) compliance gap: added `ABSPATH` direct-access guards to all 215 PHP files that were missing them across `src/`, `includes/`, and `templates/` (362 files now covered, up from 147).
- Replaced raw `echo '<style>'/'<script>'` output with `wp_enqueue_style()`/`wp_add_inline_style()`/`wp_add_inline_script()` everywhere the page-rendering architecture supports it (admin chrome CSS, checkout config), and added defense-in-depth `esc_url()` calls at 8 template output sites that were relying on escaping done earlier in the same file.
- Added the missing `EXTR_SKIP` guard to a lone `extract()` call that lacked it, matching the pattern already used at the other three call sites in the codebase.

## Details

**Security**
- `src/Database/Repositories/ProgressRepository.php`: added a `SAFE_ORDERBY` whitelist + int-clamped paging (mirrors the existing `EnrollmentRepository` pattern) to `findAll()`, `findByUser()`, `findByCourse()`, closing an ORDER BY/LIMIT interpolation path that had no whitelist.
- `src/Ajax/FrontendAjax.php`: `handleEnrollCourse()` now blocks free enrollment into paid courses, matching the two other active enrollment code paths.
- `src/Services/Frontend/AccountPageService.php`: the `sikshya_account_view_template` filter result is now required to resolve inside `WP_CONTENT_DIR` before use, instead of only checking `is_readable()`.
- `src/Database/Repositories/AdminTablesRepository.php`: removed a confusing mixed `esc_sql()` + `$wpdb->prepare()` pattern on an internal (non-user-controlled) table-name constant.

**PCP compliance**
- Added `if (!defined('ABSPATH')) { exit; }` guards to all 215 previously-unguarded files under `src/`, `includes/`, `templates/`, matching each directory's existing convention.
- `src/Admin/Admin.php`: converted 4 raw `echo '<style>'` blocks (admin menu icon sizing, setup-wizard submenu hiding, React-shell chrome, dismissible-notice hiding) into a single `wp_register_style('sikshya-admin-inline', false, ...)` handle with `wp_add_inline_style()` calls, hooked on `admin_enqueue_scripts` instead of `admin_head`.
- `templates/checkout.php`: replaced an inline `<script>window.sikshyaCheckoutConfig = ...</script>` block with `wp_add_inline_script('sikshya-checkout-page', ..., 'before')`.
- 8 template echo sites (`account.php`, `single-lesson.php`, `single-quiz.php`, `learn.php`, `admin/setup-wizard.php`) now call `esc_url()` at the point of output rather than relying on an earlier assignment.
- `src/Admin/Views/BaseView.php`: added `EXTR_SKIP` to an `extract()` call that was missing it, preventing `$template_path` (used on the very next line) from being silently clobbered by a same-named data key.

**Deliberately out of scope** (flagged during audit, left unchanged by request):
- The `wp_kses` iframe allowlist in `LessonLearnContent.php` (`style`/`class` on embedded iframes) — semi-trusted instructor-authored content, not an anonymous XSS vector.
- The `edit_posts` capability check in `CourseController::handleDeleteCourse` — route is inert by default (gated behind the disabled `SIKSHYA_LEGACY_AJAX` flag).
- Inline `<script>`/`<style>` blocks in `CertificateRenderer.php` and the full-screen shell templates (`single-quiz.php`, `learn.php`, `order-invoice.php`, `account.php`) — these deliberately bypass `wp_head()`/`wp_footer()` by design, so `wp_enqueue_*` doesn't apply architecturally without a larger restructure.

## Test plan

- [x] `php -l` on all 219 changed files — no syntax errors
- [x] `vendor/bin/phpcs -ps --standard=phpcs.xml src includes templates sikshya.php uninstall.php` — 0 errors, 0 warnings
- [x] `vendor/bin/phpunit --testsuite unit` — 27/27 passing
- [x] Manual smoke test of checkout page (confirms `window.sikshyaCheckoutConfig` still populates correctly via the new `wp_add_inline_script` call) — see [comment](https://github.com/mantrabrain/sikshya/pull/31#issuecomment-4967018890)
- [x] Manual smoke test of an admin screen (confirms admin menu icon sizing / setup-wizard submenu hiding/notice hiding still render correctly via the new enqueue path) — see [comment](https://github.com/mantrabrain/sikshya/pull/31#issuecomment-4967018890)
